### PR TITLE
authed_usersがイベントに含まれなくなったことに伴う修正

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -3,6 +3,7 @@ module.exports = {
     clientId: process.env.SLACK_APP_CLIENT_ID,
     clientSecret: process.env.SLACK_APP_CLIENT_SECRET,
     verificationToken: process.env.SLACK_APP_VERIFICATION_TOKEN,
+    appLevelToken: process.env.SLACK_APP_LEVEL_TOKEN,
   },
   redis: {
     url: process.env.REDIS_URL || 'redis://localhost:6379',

--- a/config/production.js
+++ b/config/production.js
@@ -3,6 +3,7 @@ module.exports = {
     clientId: process.env.SLACK_APP_CLIENT_ID,
     clientSecret: process.env.SLACK_APP_CLIENT_SECRET,
     verificationToken: process.env.SLACK_APP_VERIFICATION_TOKEN,
+    appLevelToken: process.env.SLACK_APP_LEVEL_TOKEN,
   },
   redis: {
     url: process.env.REDIS_URL || 'redis://localhost:6379',

--- a/src/adaptors/slack.js
+++ b/src/adaptors/slack.js
@@ -1,5 +1,6 @@
 
 const request = require("request-promise");
+const config = require('config');
 
 async function sendWebhook(webhookUrl, body){
   const requestOptions = {
@@ -64,11 +65,28 @@ function getChannelInfo(token, channelId){
     .catch((e)=>{ console.log("Fail on getChannelInfo"); console.log(e); return e;})
 }
 
+function getAuthorizationsList(event_context){
+  const requestOptions = {
+    method: 'POST',
+    url: "https://slack.com/api/apps.event.authorizations.list",
+    json: true,
+    headers: {
+      Authorization: `Bearer ${config.slack.appLevelToken}`,
+    },
+    body: {event_context: event_context},
+  };
+
+  return request(requestOptions)
+    .then((e)=>{ return e;})
+    .catch((e)=>{ console.log("Fail on getAuthorizationsList"); console.log(e); return e;})
+}
+
 module.exports = {
   sendWebhook,
   sendMessage,
   getChannelInfo,
   revokeToken,
+  getAuthorizationsList,
 };
 
 // is_mpim

--- a/src/application/patrol-service.js
+++ b/src/application/patrol-service.js
@@ -11,13 +11,16 @@ async function handleMessage(reqBody) {
   const recentEnough = !!latestWarnLog && new Date().getTime() - latestWarnLog.ts < 20000;
 
   setTimeout(()=>{
-    const receiverUserId = patrol.pickReceiverUserId();
-    const token = store.getUserAccessToken( reqBody.team_id, receiverUserId).then((token)=>{
-      const body = (recentEnough)?
-        msg.getMessageBody('ignored',{}) :
-        msg.getMessageBody('hello', { userIds: reqBody.authed_users, tokenHolder: receiverUserId });
-      body.channel = reqBody.event.channel;
-      slack.sendMessage( token, body);
+    const authedUsers = patrol.getAuthedUsers().then((authedUsers)=>{
+      const receiverUserId = patrol.pickReceiverUserId().then((receiverUserId)=>{
+        const token = store.getUserAccessToken( reqBody.team_id, receiverUserId).then((token)=>{
+          const body = (recentEnough)?
+            msg.getMessageBody('ignored',{}) :
+            msg.getMessageBody('hello', { userIds: authedUsers, tokenHolder: receiverUserId });
+          body.channel = reqBody.event.channel;
+          slack.sendMessage( token, body);
+        });
+      });
     });
   },1000);
 


### PR DESCRIPTION
2021-02 に Slack の Event API に仕様変更 <https://api.slack.com/changelog/2020-09-15-events-api-truncate-authed-users> が入ったようで、authed_users の情報がイベントに含まれなくなり以下のエラーが発生する状況となっているようです。

```
/app/src/application/patrol.js:61
const primaryUserId = this.authedUsers.find( au => au === this.sendUserId);
^

TypeError: Cannot read property 'find' of undefined at Patrol.pickReceiverUserId (/app/src/application/patrol.js:61:44) at Timeout._onTimeout (/app/src/application/patrol-service.js:14:35) at listOnTimeout (internal/timers.js:554:17) at processTimers (internal/timers.js:497:7)
```

このPRではその対策として apps.event.authorizations.list API を用いて authed_users に相当する情報を取りに行くように修正しました。ほかによい修正方法があるかもしれませんが、ご検討のほどよろしくお願いいたします。